### PR TITLE
Why was it static...

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -48,9 +48,6 @@ use crate::util::{self, ErrBuf, KafkaDrop, NativePtr, Timeout};
 /// [`ConsumerContext`]: crate::consumer::ConsumerContext
 /// [`ProducerContext`]: crate::producer::ProducerContext
 pub trait ClientContext: Send + Sync {
-    /// Deprecated, use [`ClientContext::enable_refresh_oauth_token`] instead.
-    const ENABLE_REFRESH_OAUTH_TOKEN: bool = false;
-
     /// Whether to periodically refresh the SASL `OAUTHBEARER` token
     /// by calling [`ClientContext::generate_oauth_token`].
     ///
@@ -59,10 +56,8 @@ pub trait ClientContext: Send + Sync {
     ///
     /// This parameter is only relevant when using the `OAUTHBEARER` SASL
     /// mechanism.
-    ///
-    /// Default implementation returns the value from [`ClientContext::ENABLE_REFRESH_OAUTH_TOKEN`].
     fn enable_refresh_oauth_token(&self) -> bool {
-        Self::ENABLE_REFRESH_OAUTH_TOKEN
+        false
     }
 
     /// Receives log lines from librdkafka.

--- a/src/producer/future_producer.rs
+++ b/src/producer/future_producer.rs
@@ -152,7 +152,9 @@ pub type OwnedDeliveryResult = Result<Delivery, (KafkaError, OwnedMessage)>;
 
 // Delegates all the methods calls to the wrapped context.
 impl<C: ClientContext + 'static> ClientContext for FutureProducerContext<C> {
-    const ENABLE_REFRESH_OAUTH_TOKEN: bool = C::ENABLE_REFRESH_OAUTH_TOKEN;
+    fn enable_refresh_oauth_token(&self) -> bool {
+        self.wrapped_context.enable_refresh_oauth_token()
+    }
 
     fn log(&self, level: RDKafkaLogLevel, fac: &str, log_message: &str) {
         self.wrapped_context.log(level, fac, log_message);


### PR DESCRIPTION
Two changes:
1. Changed static `ClientContext::ENABLE_REFRESH_OAUTH_TOKEN` into dynamic `ClientContext::enable_refresh_oauth_token(&self)`. The static was really messing up operator code (you can't even make `dyn ClientContext`), and it was way easier to make the change here.
2. `AdminClient` used to have a separate librdkafka queue for getting responses to async operations (like create topic), and poll it manually in a background thread. Now it uses the main queue from its internal `Client` instance, and the instance is configured to publish oauth refresh events to the main queue. Polling is done through `Client::poll_event`, which automatically handles oauth refresh. This change was needed, because `AdminClient` would never authenticate using oauth :skull: 